### PR TITLE
Fix return in template chooser

### DIFF
--- a/Modules/templatePathChooser.py
+++ b/Modules/templatePathChooser.py
@@ -19,6 +19,7 @@ def templatePathChooser(number):
         return templatePath
     elif number == '7':
         templatePath = '/twitter/index.html'
+        return templatePath
     elif number == '8':
         templatePath = '/netflix/index.html'
         return templatePath


### PR DESCRIPTION
## Summary
- return the template path for the Twitter option
- ensure newline at EOF of template chooser

## Testing
- `python -m py_compile Modules/templatePathChooser.py`

------
https://chatgpt.com/codex/tasks/task_e_6843f223803c83279a82b08c114c8a3a