### PR TITLE
Fix message typo

### DIFF
--- a/savedCredentials.py
+++ b/savedCredentials.py
@@ -56,5 +56,5 @@ try:
     print(green + "\n" + "[!] Thanks for using this tool..." + "\n" + reset)
 except Exception as err:
     print(red + "[-] Error Occurred --> " + blue + "{}".format(err) + reset)
-    print(red + "[-] Can't run program anymore...\n[-] Quiting..." + reset)
+    print(red + "[-] Can't run program anymore...\n[-] Quitting..." + reset)
     sys.exit()


### PR DESCRIPTION
## Summary
- correct a typo in an error message in `savedCredentials.py`

## Testing
- `python3 -m py_compile savedCredentials.py`


------
https://chatgpt.com/codex/tasks/task_e_6843f2119e048327af242a8e3d3e022e